### PR TITLE
Fixed recoursion while using the complete hook

### DIFF
--- a/src/Sync.php
+++ b/src/Sync.php
@@ -103,7 +103,7 @@ abstract class Sync implements Syncable
             as_enqueue_async_action( // @phpstan-ignore-line
                 $this->get_sync_name() . '/complete',
                 [], // empty arguments array
-                $this->get_sync_group_name()
+                $this->sync_group_name
             );
         }
     }

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -97,7 +97,7 @@ abstract class Sync implements Syncable
             as_enqueue_async_action( // @phpstan-ignore-line
                 $this->get_sync_name() . '/complete',
                 [], // empty arguments array
-                $this->sync_group_name
+                ''
             );
         }
     }

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -88,6 +88,12 @@ abstract class Sync implements Syncable
             return;
         }
 
+        // avoid recoursion by not hooking a complete action while
+        // in complete context
+        if ( $action->get_hook() == $this->get_sync_name() . '/complete' ) {
+            return;
+        }
+
         $actions = as_get_scheduled_actions([
             'group' => $this->get_sync_group_name(),
             'status' => ActionScheduler_Store::STATUS_PENDING,
@@ -97,7 +103,7 @@ abstract class Sync implements Syncable
             as_enqueue_async_action( // @phpstan-ignore-line
                 $this->get_sync_name() . '/complete',
                 [], // empty arguments array
-                ''
+                $this->get_sync_group_name()
             );
         }
     }


### PR DESCRIPTION
Since we added the complete job into the same group as the actual jobs, the system always assumes that this is the last job, so a new complete job was added.