### PR TITLE
Set group name before processing chunk in Sync class

### DIFF
--- a/src/Sync.php
+++ b/src/Sync.php
@@ -195,17 +195,18 @@ abstract class Sync implements Syncable {
 			return;
 		}
 
+		$this->sync_group_name = $action->get_group();
+
 		// set the start time of the chunk
 		$action_arguments = $action->get_args();
 		if ( ! empty( $action_arguments['chunk_id'] ) ) {
 			$chunk = new Chunk( $action_arguments['chunk_id'] );
 			$chunk->set_status( ProcessStatus::STARTED );
 			$chunk->set_action_id( $action_id );
+			$chunk->set_group( $this->get_sync_group_name() );
 			$chunk->set_start( microtime( true ) );
 			$chunk->save();
 		}
-
-		$this->sync_group_name = $action->get_group();
 	}
 
 	/**


### PR DESCRIPTION
Moved the `$this->sync_group_name` assignment before processing the chunk to ensure the group name is available during initialization. This fixes potential issues with grouping logic and maintains consistency in the sync process.