### PR TITLE
Rename CSV_Sync class and file to CSV

### DIFF
--- a/src/Imports/CSV.php
+++ b/src/Imports/CSV.php
@@ -9,7 +9,7 @@ use League\Csv\InvalidArgument;
 use League\Csv\Reader;
 use League\Csv\UnavailableStream;
 
-abstract class CSV_Sync extends Import
+abstract class CSV extends Import
 {
 
     protected int $chunk_size = 5000;


### PR DESCRIPTION
Updated the class and file name from CSV_Sync to CSV for better clarity and consistency. This change simplifies the naming convention and aligns it with the intended purpose of the class.