### PR TITLE
Improve data handling with custom db and locking

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1603,16 +1603,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.3.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -1655,9 +1655,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-10-08T18:51:32+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2041,16 +2041,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.13",
+            "version": "1.12.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "9b469068840cfa031e1deaf2fa1886d00e20680f"
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9b469068840cfa031e1deaf2fa1886d00e20680f",
-                "reference": "9b469068840cfa031e1deaf2fa1886d00e20680f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
                 "shasum": ""
             },
             "require": {
@@ -2095,7 +2095,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-17T17:00:20+00:00"
+            "time": "2024-12-31T07:26:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,4 +30,13 @@
     <exclude-pattern>*.ts</exclude-pattern>
     <exclude-pattern>*.tsx</exclude-pattern>
 
+    <!-- Additional configuration to ignore specific rules in src/DB -->
+    <rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
+        <exclude-pattern>src/DB/*</exclude-pattern>
+    </rule>
+
+    <rule ref="WordPress.DB.DirectDatabaseQuery.DirectQuery">
+        <exclude-pattern>src/DB/*</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/src/DB/Base_DB.php
+++ b/src/DB/Base_DB.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace juvo\AS_Processor\DB;
+
+use wpdb;
+
+abstract class Base_DB {
+
+	/**
+	 * WordPress database wrapper instance.
+	 *
+	 * @var \wpdb
+	 */
+	protected wpdb $db;
+
+	/**
+	 * Table name (defined by subclasses).
+	 *
+	 * @var string
+	 */
+	protected string $table_name;
+
+	/**
+	 * Whether the table is initialized.
+	 *
+	 * @var bool
+	 */
+	private bool $table_checked = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		global $wpdb;
+		$this->db = $wpdb;
+	}
+
+	/**
+	 * Get the table name.
+	 *
+	 * @return string
+	 */
+	public function get_table_name(): string {
+		return $this->db->prefix . $this->table_name;
+	}
+
+	/**
+	 * Ensure the table exists.
+	 *
+	 * @return void
+	 */
+	public function ensure_table(): void {
+		if ( ! $this->table_checked ) {
+			$this->maybe_create_table();
+			$this->table_checked = true;
+		}
+	}
+
+	/**
+	 * Create the database table if it does not exist.
+	 * Must be implemented by subclasses.
+	 *
+	 * @return void
+	 */
+	abstract protected function maybe_create_table(): void;
+}

--- a/src/DB/Base_DB.php
+++ b/src/DB/Base_DB.php
@@ -1,9 +1,19 @@
 <?php
+/**
+ * Base layer for custom DB tables.
+ *
+ * @package juvo/as-processor
+ */
 
 namespace juvo\AS_Processor\DB;
 
 use wpdb;
 
+/**
+ * Abstract class Base_DB.
+ * Serves as a base for database-related functionality,
+ * providing a structure for interacting with custom database tables.
+ */
 abstract class Base_DB {
 
 	/**

--- a/src/DB/Data_DB.php
+++ b/src/DB/Data_DB.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Handles the database.
+ *
+ * @package juvo\AS_Processor
+ */
+
+namespace juvo\AS_Processor\DB;
+
+class Data_DB extends Base_DB {
+
+
+	protected string $table_name = 'asp_data';
+
+	/**
+	 * Define the table schema and create the table if it doesn't exist.
+	 *
+	 * @return void
+	 */
+	protected function maybe_create_table(): void {
+		$charset_collate = $this->db->get_charset_collate();
+		$table_name      = $this->get_table_name();
+
+		$sql = "CREATE TABLE {$table_name} (
+            `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) NOT NULL,
+            `data` longtext NOT NULL,
+            `expires` DATETIME NOT NULL,
+            PRIMARY KEY (`id`),
+        	UNIQUE KEY `unique_name` (`name`)
+        ) {$charset_collate}";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Delete expired data entries.
+	 *
+	 * @return void
+	 */
+	public function delete_expired_data(): void {
+		$table_name = $this->get_table_name();
+		$this->db->query(
+			$this->db->prepare( "DELETE FROM {$table_name} WHERE expires < %s", current_time( 'mysql' ) )
+		);
+	}
+
+	/**
+	 * Replace a record in the database with the provided name, value, and expiration timestamp.
+	 *
+	 * @param string $name The name of the record to replace.
+	 * @param mixed  $value The value to associate with the record, which will be serialized before storing.
+	 * @param int    $timestamp The number of seconds from now when the record should expire.
+	 *
+	 * @return \mysqli_result|bool|int|null The result of the database operation, which may vary depending on the database driver and context.
+	 */
+	public function replace( string $name, mixed $value, int $timestamp ): \mysqli_result|bool|int|null {
+		// Serialize the data for the database
+		$serialized_data = maybe_serialize( $value );
+
+		// Expiration time
+		$expires = gmdate( 'Y-m-d H:i:s', time() + $timestamp );
+
+		// Insert or update the data in the database
+		global $wpdb;
+		return $wpdb->replace(
+			$this->get_table_name(),
+			array(
+				'name'    => $name,
+				'data'    => $serialized_data,
+				'expires' => $expires,
+			),
+			array( '%s', '%s', '%s' )
+		);
+	}
+
+	/**
+	 * Retrieve data from the database by name.
+	 *
+	 * @param string $name The name of the data to retrieve.
+	 * @return array|false The full row if available and not expired, or false if not found or expired.
+	 */
+	public function get( string $name ): array|false {
+		// Try to get the data from the database
+		$row = $this->db->get_row(
+			$this->db->prepare(
+				"SELECT * FROM {$this->get_table_name()} WHERE `name` = %s LIMIT 1",
+				$name
+			),
+			ARRAY_A
+		);
+
+		if ( ! $row ) {
+			return false; // No data found
+		}
+
+		// Check expiration
+		if ( strtotime( $row['expires'] ) < time() ) {
+			$this->delete( $name );
+			return false; // Data is expired
+		}
+
+		// Unserialize the data before returning
+		$row['data'] = maybe_unserialize( $row['data'] );
+
+		return $row;
+	}
+
+	/**
+	 * Delete a data entry based on the provided name.
+	 *
+	 * @param string $name The name of the entry to be deleted.
+	 * @return \mysqli_result|bool|int|null The result of the delete operation, which may vary depending on the database implementation.
+	 */
+	public function delete( string $name ): \mysqli_result|bool|int|null {
+		return $this->db->delete( $this->get_table_name(), array( 'name' => $name ) );
+	}
+}

--- a/src/DB/Data_DB.php
+++ b/src/DB/Data_DB.php
@@ -26,6 +26,8 @@ class Data_DB extends Base_DB {
             `name` varchar(255) NOT NULL,
             `data` longtext NOT NULL,
             `expires` DATETIME NOT NULL,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`),
         	UNIQUE KEY `unique_name` (`name`)
         ) {$charset_collate}";

--- a/src/DB/Data_DB.php
+++ b/src/DB/Data_DB.php
@@ -7,9 +7,20 @@
 
 namespace juvo\AS_Processor\DB;
 
+/**
+ * Class Data_DB
+ *
+ * This class provides an interface for interacting with a database table that stores data entries.
+ * It supports operations such as table creation, data insertion, retrieval, deletion, and expiration management.
+ */
 class Data_DB extends Base_DB {
 
 
+	/**
+	 * The name of the table.
+	 *
+	 * @var string
+	 */
 	protected string $table_name = 'asp_data';
 
 	/**
@@ -81,9 +92,11 @@ class Data_DB extends Base_DB {
 	 * Retrieve data from the database by name.
 	 *
 	 * @param string $name The name of the data to retrieve.
-	 * @return array|false The full row if available and not expired, or false if not found or expired.
+	 * @param string $column Optional. A specific column to return from the data row. Defaults to an empty string.
+	 *
+	 * @return array|false The data row as an associative array, a specific column's value if specified, or false if not found or expired.
 	 */
-	public function get( string $name ): array|false {
+	public function get( string $name, string $column = '' ): array|false {
 		// Try to get the data from the database
 		$row = $this->db->get_row(
 			$this->db->prepare(
@@ -105,6 +118,14 @@ class Data_DB extends Base_DB {
 
 		// Unserialize the data before returning
 		$row['data'] = maybe_unserialize( $row['data'] );
+
+		// Maybe only return the one key
+		if ( $column ) {
+			if ( ! empty( $row[ $column ] ) ) {
+				return $row[ $column ];
+			}
+			return false;
+		}
 
 		return $row;
 	}

--- a/src/Imports/CSV.php
+++ b/src/Imports/CSV.php
@@ -9,7 +9,7 @@ use League\Csv\InvalidArgument;
 use League\Csv\Reader;
 use League\Csv\UnavailableStream;
 
-abstract class CSV_Sync extends Import
+abstract class CSV extends Import
 {
 
     protected int $chunk_size = 5000;

--- a/src/Sequential_Sync.php
+++ b/src/Sequential_Sync.php
@@ -101,7 +101,7 @@ abstract class Sequential_Sync extends Sync implements Syncable {
 		add_action(
 			$this->get_sync_name() . '/complete',
 			function () {
-				$this->cleanup_sync_data( $this->get_sync_data_name() );
+				$this->cleanup_sync_data();
 			},
 			999
 		);

--- a/src/Sequential_Sync.php
+++ b/src/Sequential_Sync.php
@@ -101,7 +101,7 @@ abstract class Sequential_Sync extends Sync implements Syncable {
 		add_action(
 			$this->get_sync_name() . '/complete',
 			function () {
-				$this->cleanup_sync_data();
+				$this->cleanup_sync_data( $this->get_sync_data_name() );
 			},
 			999
 		);

--- a/src/Sequential_Sync.php
+++ b/src/Sequential_Sync.php
@@ -98,7 +98,9 @@ abstract class Sequential_Sync extends Sync implements Syncable {
 		add_action( $this->get_sync_name(), array( $this, 'callback' ) );
 
 		// Delete sync data after sync is complete
-		add_action( $this->get_sync_name() . '/complete', array( $this, 'delete_sync_data' ), 999 );
+		add_action( $this->get_sync_name() . '/complete', function() {
+			$this->cleanup_sync_data($this->get_sync_data_name());
+		}, 999 );
 	}
 
 	/**

--- a/src/Sequential_Sync.php
+++ b/src/Sequential_Sync.php
@@ -98,9 +98,13 @@ abstract class Sequential_Sync extends Sync implements Syncable {
 		add_action( $this->get_sync_name(), array( $this, 'callback' ) );
 
 		// Delete sync data after sync is complete
-		add_action( $this->get_sync_name() . '/complete', function() {
-			$this->cleanup_sync_data($this->get_sync_data_name());
-		}, 999 );
+		add_action(
+			$this->get_sync_name() . '/complete',
+			function () {
+				$this->cleanup_sync_data( $this->get_sync_data_name() );
+			},
+			999
+		);
 	}
 
 	/**

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -190,7 +190,6 @@ abstract class Sync implements Syncable {
 		// Check if action of the same group is running or pending
 		$actions = $this->get_actions( status: array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ), per_page: 1 );
 		if ( count( $actions ) === 0 ) {
-			$this->cleanup_stale_locks();
 			as_enqueue_async_action(
 				$this->get_sync_name() . '/complete',
 				array(), // empty arguments array

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -94,12 +94,12 @@ abstract class Sync implements Syncable {
 				// schedule the cleanup midnight every day
 				as_schedule_cron_action(
 					time(),
-					'0 * * * *',
+					'0 0 * * *',
 					'asp/sync_data/cleanup'
 				);
 			}
 		);
-		add_action( 'asp/chunks/cleanup', array( $this, 'cleanup_sync_data' ) );
+		add_action( 'asp/sync_data/cleanup', array( $this, 'cleanup_sync_data' ) );
 	}
 
 	/**

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -75,25 +75,30 @@ abstract class Sync implements Syncable {
 		}
 
 		// Hooks for chunk cleanup
-		add_action('init', function () {
+		add_action(
+			'init',
+			function () {
 				$this->schedule_chunk_cleanup();
 			}
 		);
 		add_action( 'asp/chunks/cleanup', array( $this, 'cleanup_chunk_data' ) );
 
 		// Hook Sync Data Cleanup
-		add_action( 'init', function() {
-			if ( as_has_scheduled_action( 'asp/sync_data/cleanup' ) ) {
-				return;
-			}
+		add_action(
+			'init',
+			function () {
+				if ( as_has_scheduled_action( 'asp/sync_data/cleanup' ) ) {
+					return;
+				}
 
-			// schedule the cleanup midnight every day
-			as_schedule_cron_action(
-				time(),
-				'0 * * * *',
-				'asp/sync_data/cleanup'
-			);
-		});
+				// schedule the cleanup midnight every day
+				as_schedule_cron_action(
+					time(),
+					'0 * * * *',
+					'asp/sync_data/cleanup'
+				);
+			}
+		);
 		add_action( 'asp/chunks/cleanup', array( $this, 'cleanup_sync_data' ) );
 	}
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -219,7 +219,7 @@ trait Sync_Data {
 	 * @param string $force_delete_group Optional. A group identifier to forcefully delete matching options. Defaults to an empty string.
 	 * @return void
 	 */
-	protected function cleanup_sync_data( string $force_delete_group = '' ): void {
+	public function cleanup_sync_data( string $force_delete_group = '' ): void {
 		global $wpdb;
 
 		// Query options table for keys matching the pattern.

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -120,15 +120,18 @@ trait Sync_Data {
 				return;
 			} catch ( Sync_Data_Lock_Exception $e ) {
 				// Add random jitter to the delay (8% jitter in both directions)
-				$jitter = rand(-80000, 80000) / 1000000; // Random jitter between -0.08s and +0.08s
-				$delay = (int) ($delay + $jitter);
+				$jitter = wp_rand( -80000, 80000 ) / 1000000; // Random jitter between -0.08s and +0.08s
+				$delay  = (int) ( $delay + $jitter );
 
-				/* translators: 1: Exception message, 2: Number of seconds the process will wait till next retry. */
-				$this->log( sprintf( esc_attr__( '%1$s Next try in %2$s seconds.', 'as-processor' ),
-					esc_attr( $e->getMessage() ),
-					number_format( $delay, 2 )
-				));
-				usleep($delay * 1000000);
+				$this->log(
+					sprintf(
+					/* translators: 1: Exception message, 2: Number of seconds the process will wait till next retry. */
+						esc_attr__( '%1$s Next try in %2$s seconds.', 'as-processor' ),
+						esc_attr( $e->getMessage() ),
+						number_format( $delay, 2 )
+					)
+				);
+				usleep( $delay * 1000000 );
 
 				$total_wait_time += $delay;
 			}
@@ -179,7 +182,7 @@ trait Sync_Data {
 	 * @link https://github.com/rhubarbgroup/redis-cache/issues/523
 	 */
 	private function get_option( string $key ) {
-		if (!str_contains($key, 'asp_')) {
+		if ( ! str_contains( $key, 'asp_' ) ) {
 			$key = 'asp_' . $key;
 		}
 
@@ -208,7 +211,7 @@ trait Sync_Data {
 	 * @return bool True if the option value was successfully updated, false otherwise.
 	 */
 	protected function update_option( string $key, mixed $value, int $timestamp ): bool {
-		if (!str_contains($key, 'asp_')) {
+		if ( ! str_contains( $key, 'asp_' ) ) {
 			$key = 'asp_' . $key;
 		}
 
@@ -254,7 +257,7 @@ trait Sync_Data {
 				delete_option( $option_name );
 			}
 
-			if(!$this->get_option( $option_name )) {
+			if ( ! $this->get_option( $option_name ) ) {
 				delete_option( $option_name );
 			}
 		}

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -174,6 +174,7 @@ trait Sync_Data {
 	 * @link https://github.com/rhubarbgroup/redis-cache/issues/523
 	 */
 	private function get_option( string $key ) {
+		$key = 'asp_' . $key;
 
 		if ( ! wp_using_ext_object_cache() ) {
 
@@ -201,7 +202,7 @@ trait Sync_Data {
 	 */
 	protected function update_option( string $key, mixed $value, int $timestamp ): bool {
 		return update_option(
-			$key,
+			'asp_' . $key,
 			array(
 				'timestamp' => time() + $timestamp,
 				'value'     => $value,
@@ -227,7 +228,7 @@ trait Sync_Data {
 			"
         SELECT option_name 
         FROM {$wpdb->options} 
-        WHERE option_name LIKE %%asp",
+        WHERE option_name LIKE %%asp_",
 			ARRAY_A
 		);
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -114,7 +114,7 @@ trait Sync_Data {
 				}
 
 				// Save the updated data back into the transient.
-				set_transient( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
+				$this->update_option( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
 
 				// Release lock
 				$this->set_key_lock( $key, false );

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -174,7 +174,9 @@ trait Sync_Data {
 	 * @link https://github.com/rhubarbgroup/redis-cache/issues/523
 	 */
 	private function get_option( string $key ) {
-		$key = 'asp_' . $key;
+		if (!str_contains($key, 'asp_')) {
+			$key = 'asp_' . $key;
+		}
 
 		if ( ! wp_using_ext_object_cache() ) {
 
@@ -201,8 +203,12 @@ trait Sync_Data {
 	 * @return bool True if the option value was successfully updated, false otherwise.
 	 */
 	protected function update_option( string $key, mixed $value, int $timestamp ): bool {
+		if (!str_contains($key, 'asp_')) {
+			$key = 'asp_' . $key;
+		}
+
 		return update_option(
-			'asp_' . $key,
+			$key,
 			array(
 				'timestamp' => time() + $timestamp,
 				'value'     => $value,
@@ -225,10 +231,13 @@ trait Sync_Data {
 
 		// Query options table for keys matching the pattern.
 		$results = $wpdb->get_results(
-			"
-        SELECT option_name 
-        FROM {$wpdb->options} 
-        WHERE option_name LIKE %%asp_",
+			$wpdb->prepare(
+				"
+           SELECT option_name 
+           FROM {$wpdb->options} 
+           WHERE option_name LIKE %s",
+				'asp_%' // sanitize the LIKE pattern
+			),
 			ARRAY_A
 		);
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -119,8 +119,8 @@ trait Sync_Data {
 
 				return;
 			} catch ( Sync_Data_Lock_Exception $e ) {
-				// Add random jitter to the delay (5% jitter in both directions)
-				$jitter = rand(-50000, 50000) / 1000000; // Random jitter between -0.05s and +0.05s
+				// Add random jitter to the delay (8% jitter in both directions)
+				$jitter = rand(-80000, 80000) / 1000000; // Random jitter between -0.08s and +0.08s
 				$delay = (int) ($delay + $jitter);
 
 				/* translators: 1: Exception message, 2: Number of seconds the process will wait till next retry. */

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -167,7 +167,7 @@ trait Sync_Data {
 
 		if ( $state ) {
 			// Try to acquire a lock using MySQL GET_LOCK
-			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $db_lock_key, 2 ) );
+			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $db_lock_key, 0.5 ) );
 
 			if ( ! $result ) {
 				throw new Sync_Data_Lock_Exception(

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -85,7 +85,6 @@ trait Sync_Data {
 	 * @param int    $expiration Optional. The expiration time (in seconds) for the updated data. Default is 6 hours.
 	 *
 	 * @return void
-	 * @throws Sync_Data_Lock_Exception If the data update fails due to conflicting locks.
 	 * @throws Exception If the maximum retry time is reached.
 	 */
 	protected function update_sync_data( string $key, mixed $updates, bool $deep_merge = false, bool $concat_arrays = false, int $expiration = HOUR_IN_SECONDS * 6 ): void {

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -149,13 +149,13 @@ trait Sync_Data {
 			throw new Sync_Data_Lock_Exception( esc_attr( sprintf( 'Another process owns the lock for %s', $lock_key ) ) );
 		}
 
-		if ( $state ) {
-			$lock_ttl = apply_filters( 'asp/sync_data/lock_ttl', 5 * MINUTE_IN_SECONDS, $key );
+		$lock_ttl = apply_filters( 'asp/sync_data/lock_ttl', 5 * MINUTE_IN_SECONDS, $key );
 
+		if ( $state ) {
 			// Setting the lock with the pid
 			$this->update_option( $lock_key, getmypid(), $lock_ttl );
 		} else {
-			delete_option( $lock_key );
+			$this->update_option( $lock_key, false, $lock_ttl );
 		}
 	}
 
@@ -185,7 +185,7 @@ trait Sync_Data {
 		}
 
 		if ( empty( $data['value'] ) || ( isset( $data['timestamp'] ) && $data['timestamp'] < time() ) ) {
-			delete_option( $key );
+			return false;
 		}
 
 		return $data['value'];
@@ -239,7 +239,9 @@ trait Sync_Data {
 				delete_option( $option_name );
 			}
 
-			$this->get_option( $option_name );
+			if(!$this->get_option( $option_name )) {
+				delete_option( $option_name );
+			}
 		}
 	}
 }

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -205,6 +205,7 @@ trait Sync_Data {
 				} else {
 					$this->get_data_db()->replace( $lock_key, false, $lock_ttl );
 				}
+				return;
 			} catch ( Sync_Data_Lock_Exception $e ) {
 				// Add random jitter to the delay (8% jitter in both directions)
 				$jitter = wp_rand( -80000, 80000 ) / 1000000; // Random jitter between -0.08s and +0.08s

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -121,7 +121,7 @@ trait Sync_Data {
 			} catch ( Sync_Data_Lock_Exception $e ) {
 				// Add random jitter to the delay (8% jitter in both directions)
 				$jitter = wp_rand( -80000, 80000 ) / 1000000; // Random jitter between -0.08s and +0.08s
-				$delay  = (int) ( $delay + $jitter );
+				$delay  = $delay + $jitter;
 
 				$this->log(
 					sprintf(
@@ -131,7 +131,7 @@ trait Sync_Data {
 						number_format( $delay, 2 )
 					)
 				);
-				usleep( $delay * 1000000 );
+				usleep( (int) $delay * 1000000 );
 
 				$total_wait_time += $delay;
 			}

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -102,10 +102,10 @@ trait Sync_Data {
 	 */
 	protected function update_sync_data( string $key, mixed $updates, bool $deep_merge = false, bool $concat_arrays = false, int $expiration = HOUR_IN_SECONDS * 6 ): void {
 
-			// Set lock
-			$this->set_key_lock( $key, true );
+		// Set lock
+		$this->set_key_lock( $key, true );
 
-			// Handle merging logic
+		// Handle merging logic
 		if ( $deep_merge || $concat_arrays ) {
 
 			// Retrieve the current data.
@@ -121,7 +121,7 @@ trait Sync_Data {
 			}
 		}
 
-			$success = $this->get_data_db()->replace( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
+		$success = $this->get_data_db()->replace( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
 		if ( ! $success ) {
 			throw new Exception(
 			/* translators: 1: The key name of the sync data trying to update. */
@@ -129,8 +129,8 @@ trait Sync_Data {
 			);
 		}
 
-			// Release lock
-			$this->set_key_lock( $key, false );
+		// Release lock
+		$this->set_key_lock( $key, false );
 	}
 
 	/**

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -126,7 +126,7 @@ trait Sync_Data {
 				$this->log(
 					sprintf(
 					/* translators: 1: Exception message, 2: Number of seconds the process will wait till next retry. */
-						esc_attr__( '%1$s Next try in %2$s seconds.', 'as-processor' ),
+						esc_attr__( '%1$s. Next try in %2$s seconds.', 'as-processor' ),
 						esc_attr( $e->getMessage() ),
 						number_format( $delay, 2 )
 					)

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -18,7 +18,8 @@ use juvo\AS_Processor\Entities\Sync_Data_Lock_Exception;
  * proper locking and concurrency handling.
  * It also supports advanced merging and concatenating options for array-type synchronization data.
  */
-trait Sync_Data {
+trait Sync_Data
+{
 
 	/**
 	 * Sync Data Name.
@@ -30,37 +31,21 @@ trait Sync_Data {
 	private string $sync_data_name;
 
 	/**
-	 * List of data keys that are locked by the current process.
-	 *
-	 * @var string[]
-	 */
-	private array $locked_by_current_process = array();
-
-	/**
 	 * Returns the sync data from a transient
 	 *
 	 * @param string $key Key of the sync data to retrieve.
 	 * @return mixed
 	 */
-	protected function get_sync_data( string $key ): mixed {
-		$transient = $this->get_transient( $this->get_sync_data_name() . '_' . $key );
+	protected function get_sync_data(string $key): mixed
+	{
+		$transient = $this->get_option($this->get_sync_data_name() . '_' . $key);
 
 		// Return false if there's no data
-		if ( empty( $transient ) ) {
+		if (empty($transient)) {
 			return false;
 		}
 
 		return $transient;
-	}
-
-	/**
-	 * Checks if a lock is currently held.
-	 *
-	 * @param string $key The key of the transient.
-	 * @return bool True if the lock is held, false otherwise.
-	 */
-	protected function is_locked( string $key ): bool {
-		return (bool) $this->get_transient( $this->get_sync_data_name() . '_' . $key . '_lock' );
 	}
 
 	/**
@@ -69,9 +54,10 @@ trait Sync_Data {
 	 *
 	 * @return string
 	 */
-	public function get_sync_data_name(): string {
+	public function get_sync_data_name(): string
+	{
 		// Set sync data key to the group name by default. Sequential Sync does not have a group name
-		if ( empty( $this->sync_data_name ) && method_exists( $this, 'get_sync_group_name' ) ) {
+		if (empty($this->sync_data_name) && method_exists($this, 'get_sync_group_name')) {
 			$this->sync_data_name = $this->get_sync_group_name();
 			return $this->sync_data_name;
 		}
@@ -86,180 +72,178 @@ trait Sync_Data {
 	 * @param string $sync_data_name The name to be assigned to the synchronization data.
 	 * @return void
 	 */
-	public function set_sync_data_name( string $sync_data_name ): void {
+	public function set_sync_data_name(string $sync_data_name): void
+	{
 		$this->sync_data_name = $sync_data_name;
 	}
 
 	/**
-	 * Updates synchronization data with new values, applying optional merge strategies.
-	 *
-	 * This method retrieves the current data associated with the given key, applies the specified updates,
-	 * and saves the modified data back with the defined expiration. The process respects specified merge
-	 * and concatenation behaviors and includes a retry mechanism for ensuring successful execution.
+	 * Updates synchronization data directly in the options table.
 	 *
 	 * @param string $key The key identifying the synchronization data to update.
-	 * @param mixed  $updates The data to update the synchronization data with.
-	 * @param bool   $deep_merge Optional. Whether to perform a deep merge of arrays. Default is false.
-	 * @param bool   $concat_arrays Optional. Whether to concatenate arrays instead of overriding. Default is false.
-	 * @param int    $expiration Optional. The expiration time (in seconds) for the updated data. Default is 6 hours.
+	 * @param mixed $updates The data to update the synchronization data with.
+	 * @param bool $deep_merge Optional. Whether to perform a deep merge of arrays. Default is false.
+	 * @param bool $concat_arrays Optional. Whether to concatenate arrays instead of overriding. Default is false.
+	 * @param int $expiration Optional. The expiration time (in seconds) for the updated data. Default is 6 hours.
 	 *
 	 * @return void
-	 *
-	 * @throws Sync_Data_Lock_Exception If the data update fails after multiple attempts.
-	 * @throws Exception Thrown when the maximum backoff time is reached and the process failed.
+	 * @throws Sync_Data_Lock_Exception If the data update fails due to conflicting locks.
+	 * @throws Exception If the maximum retry time is reached.
 	 */
-	protected function update_sync_data( string $key, mixed $updates, bool $deep_merge = false, bool $concat_arrays = false, int $expiration = HOUR_IN_SECONDS * 6 ): void {
+	protected function update_sync_data(string $key, mixed $updates, bool $deep_merge = false, bool $concat_arrays = false, int $expiration = HOUR_IN_SECONDS * 6): void
+	{
 
-		$delay           = 0.1; // Initial delay in seconds
+		$delay = 0.1; // Initial delay in seconds
 		$total_wait_time = 0;
 
 		do {
 			try {
+				// Set lock
+				$this->set_key_lock($key, true);
 
-				// Lock data first
-				if ( $this->is_locked( $key ) && ! $this->is_key_locked_by_current_process( $key ) ) {
-					/* translators: 1: Key being locked, 2: Number of seconds the process waited for the lock release. */
-					throw new Sync_Data_Lock_Exception( sprintf( esc_attr__( 'Lock for "%1$s" is already acquired by another process. Waited %2$s seconds to acquire the lock.', 'as-processor' ), esc_attr( $key ), number_format( $total_wait_time, 2 ) ) );
-				}
+				// Handle merging logic
+				if ($deep_merge || $concat_arrays) {
 
-				$this->set_key_lock( $key, true );
-
-				// Check if values is supposed to be an array
-				if ( $deep_merge || $concat_arrays ) {
-
-					// Retrieve the current transient data.
-					$current_data = $this->get_sync_data( $key );
+					// Retrieve the current data.
+					$current_data = $this->get_sync_data($key);
 
 					// If current data not initialized yet make it an array
-					if ( ! $current_data ) {
+					if (!$current_data) {
 						$current_data = array();
 					}
 
-					// At this point if current data is an array and one of the merge options is used we can assume the update should also be an array to be merged
-					if ( is_array( $current_data ) && ! is_array( $updates ) ) {
-						$updates = array( $updates );
-					}
-
-					// Merge the new updates into the current data, respecting the deepMerge and concatArrays flags.
-					if ( is_array( $current_data ) && is_array( $updates ) ) {
-						$updates = Helper::merge_arrays( $current_data, $updates, $deep_merge, $concat_arrays );
+					if (is_array($current_data) && is_array($updates)) {
+						$updates = Helper::merge_arrays($current_data, $updates, $deep_merge, $concat_arrays);
 					}
 				}
 
 				// Save the updated data back into the transient.
-				set_transient( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
+				set_transient($this->get_sync_data_name() . '_' . $key, $updates, $expiration);
 
-				// Unlock
-				$this->set_key_lock( $key, false );
+				// Release lock
+				$this->set_key_lock($key, false);
+
 				return;
-			} catch ( Sync_Data_Lock_Exception $e ) {
-				$this->log( $e->getMessage() );
+			} catch (Sync_Data_Lock_Exception $e) {
+				$this->log($e->getMessage());
 
-				usleep( (int) ( $delay * 1000000 ) ); // Convert delay to microseconds
+				usleep((int)($delay * 1000000)); // Convert delay to microseconds
 				$total_wait_time += $delay;
-				$delay           *= 2; // Double the delay
+				$delay *= 2; // Double the delay
 				continue;
 			}
-		} while ( $total_wait_time < floatval( apply_filters( 'asp/sync_data/max_wait_time', 5, $key, $total_wait_time ) ) );
+		} while ($total_wait_time < floatval(apply_filters('asp/sync_data/max_wait_time', 5, $key, $total_wait_time)));
+
+		// Cleanup the failed lock before throwing an exception
+		$this->set_key_lock($key, false);
 
 		/* translators: 1: Key being locked, 2: Number of seconds the process waited for the lock release. */
-		throw new Exception( sprintf( esc_attr__( 'Failed to update sync data "%1$s". Tried %2$s seconds.', 'as-processor' ), esc_attr( $key ), number_format( $total_wait_time, 2 ) ) );
+		throw new Exception(sprintf(esc_attr__('Failed to update sync data "%1$s". Tried %2$s seconds.', 'as-processor'), esc_attr($key), number_format($total_wait_time, 2)));
 	}
 
 	/**
-	 * Get the most recent transient value
+	 * Set a lock state for a specific key with an optional expiration (TTL).
 	 *
-	 * Due to the nature of transients and how WordPress handels object caching, this wrapper is needed to always get
+	 * @param string $key The key for which the lock state is being set.
+	 * @param bool $state Determines whether to enable (true) or disable (false) the key lock.
+	 * @return void
+	 * @throws Sync_Data_Lock_Exception When the current lock is set by another process.
+	 */
+	protected function set_key_lock(string $key, bool $state): void
+	{
+		$lock_key = $this->get_sync_data_name() . '_' . $key . '_lock';
+		$lock_content = $this->get_option($lock_key);
+
+		if ($lock_content && $lock_content !== getmypid()) {
+			throw new Sync_Data_Lock_Exception(sprintf('Another process owns the lock for %s', $lock_key));
+		}
+
+		if ($state) {
+			$lock_ttl = apply_filters('asp/sync_data/lock_ttl', 5 * MINUTE_IN_SECONDS, $key);
+
+			// Setting the lock with the pid
+			$this->update_option($lock_key, getmypid(), $lock_ttl);
+		} else {
+			delete_option($lock_key);
+		}
+	}
+
+	/**
+	 * Get the most recent option value
+	 *
+	 * Due to the nature of options and how WordPress handels object caching, this wrapper is needed to always get
 	 * the most recent value from the cache.
 	 *
-	 * WordPress caches transients in the options group if no external object cache is used.
+	 * WordPress caches transients and options if no external object cache is used.
 	 * These caches are also deleted before querying the new db value.
 	 *
-	 * When an external object cache is used, the get_transient is avoided completely and a forced wp_cache_get is used.
+	 * When an external object cache is used a forced wp_cache_get is used.
 	 *
 	 * @param string $key Key of the transient to get.
 	 * @link https://github.com/rhubarbgroup/redis-cache/issues/523
 	 */
-	private function get_transient( string $key ) {
+	private function get_option(string $key)
+	{
 
-		if ( ! wp_using_ext_object_cache() ) {
+		if (!wp_using_ext_object_cache()) {
 
 			// Delete transient cache
-			$deletion_key = '_transient_' . $key;
-			wp_cache_delete( $deletion_key, 'options' );
-
-			// Delete timeout cache
-			$deletion_key = '_transient_timeout_' . $key;
-			wp_cache_delete( $deletion_key, 'options' );
-
-			// At this point object cache is cleared and can be requested again
-			$data = get_transient( $key );
+			wp_cache_delete($key, 'options');
+			$data = get_option($key);
 		} else {
-			$data = wp_cache_get( $key, 'transient', true );
+			$data = wp_cache_get($key, 'transient', true);
 		}
 
-		return $data;
+		if( empty($data['value']) || isset( $data['timestamp'] ) && $data['timestamp'] < time()) {
+			delete_option($key);
+		}
+
+		return $data['value'];
 	}
 
 	/**
-	 * Fully deletes the sync data
+	 * Updates an option in the options table with a new value and timestamp.
 	 *
+	 * @param string $key The option name or key to update.
+	 * @param mixed $value The new value to be stored.
+	 * @param int $timestamp The timestamp offset to be added to the current time.
+	 * @return bool True if the option value was successfully updated, false otherwise.
+	 */
+	protected function update_option(string $key, mixed $value, int $timestamp): bool
+	{
+		return update_option($key, [
+			'timestamp' => time() + $timestamp,
+			'value' => $value
+		], false);
+	}
+
+	/**
+	 * Delete all locks of a sync from the options table
+	 *
+	 * @param string $force_delete_group
 	 * @return void
 	 */
-	public function delete_sync_data(): void {
+	protected function cleanup_sync_data(string $force_delete_group = ""): void
+	{
 		global $wpdb;
 
-		// Define the base name of your transient
-		$base_transient_name = $this->get_sync_data_name() . '_';
+		// Query options table for keys matching the pattern.
+		$query = $wpdb->prepare("
+        SELECT option_name 
+        FROM {$wpdb->options} 
+        WHERE option_name LIKE %%asp");
 
-		// Prepare the like pattern for SQL, escaping wildcards and adding the wildcard placeholder
-		$like_pattern = $wpdb->esc_like( '_transient_' . $base_transient_name ) . '%';
+		$results = $wpdb->get_results($query, ARRAY_A);
 
-		// Use $wpdb to directly delete transients from the wp_options table
-		$wpdb->query(
-			$wpdb->prepare(
-				"
-                DELETE FROM $wpdb->options
-                WHERE option_name LIKE %s
-                ",
-				$like_pattern
-			)
-		);
-	}
+		foreach ($results as $row) {
+			$option_name = $row['option_name'];
 
-	/**
-	 * Determines if the given key is currently locked by the current process.
-	 *
-	 * This method checks if the specified key is marked as locked in the
-	 * context of the current process.
-	 *
-	 * @param string $key The unique identifier for the lock.
-	 * @return bool True if the key is locked by the current process, otherwise false.
-	 */
-	protected function is_key_locked_by_current_process( string $key ): bool {
-		return isset( $this->locked_by_current_process[ $key ] ) && $this->locked_by_current_process[ $key ];
-	}
+			// Maybe force delete option
+			if (!empty($force_delete_group) && str_contains($option_name, $force_delete_group)) {
+				delete_option($option_name);
+			}
 
-	/**
-	 * Set a lock state for a specific key with an optional time-to-live (TTL).
-	 *
-	 * This method updates the lock state for the specified key and sets a transient lock with a given TTL, if the state is true.
-	 * The lock helps in synchronizing processes to prevent conflicts.
-	 *
-	 * @param string $key The key for which the lock state is being set.
-	 * @param bool   $state Determines whether to enable (true) or disable (false) the key lock.
-	 * @return void
-	 */
-	protected function set_key_lock( string $key, bool $state ): void {
-		$this->locked_by_current_process[ $key ] = $state;
-
-		if ( $state ) {
-			// Allow the lock TTL to be filtered using a specific hook.
-			$lock_ttl = apply_filters( 'asp/sync_data/lock_ttl', 5 * MINUTE_IN_SECONDS, $key );
-
-			set_transient( $this->get_sync_data_name() . '_' . $key . '_lock', true, $lock_ttl );
-		} else {
-			delete_transient( $this->get_sync_data_name() . '_' . $key . '_lock' );
+			$this->get_option($option_name);
 		}
 	}
 }


### PR DESCRIPTION
Added Db native locking and data locking as fallback. A new database table serves as plain and simple storage without a lot of the overhead caused by wordPress in-built caching