### PR TITLE
More verbose update error

### DIFF
--- a/src/DB/Base_DB.php
+++ b/src/DB/Base_DB.php
@@ -78,6 +78,15 @@ abstract class Base_DB {
 	}
 
 	/**
+	 * Get the last error
+	 *
+	 * @return string
+	 */
+	public function get_last_error(): string {
+		return $this->db->last_error;
+	}
+
+	/**
 	 * Ensure the table exists.
 	 *
 	 * @return void

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -105,7 +105,7 @@ trait Sync_Data {
 		if ( ! $success ) {
 			throw new Exception(
 			/* translators: 1: The key name of the sync data trying to update., 2: The last db error. */
-				sprintf( esc_attr__( 'Failed to update sync data for key %1$s: %2$s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: "" ) )
+				sprintf( esc_attr__( 'Failed to update sync data for key %1$s: %2$s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: '' ) )
 			);
 		}
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -104,8 +104,8 @@ trait Sync_Data {
 		$success = Data_DB::db()->replace( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
 		if ( ! $success ) {
 			throw new Exception(
-			/* translators: 1: The key name of the sync data trying to update. */
-				sprintf( esc_attr__( 'Failed to update sync data for key %s', 'as-processor' ), esc_attr( $key ) )
+			/* translators: 1: The key name of the sync data trying to update., 2: The last db error. */
+				sprintf( esc_attr__( 'Failed to update sync data for key %s: %s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: "" ) )
 			);
 		}
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -105,7 +105,7 @@ trait Sync_Data {
 		if ( ! $success ) {
 			throw new Exception(
 			/* translators: 1: The key name of the sync data trying to update., 2: The last db error. */
-				sprintf( esc_attr__( 'Failed to update sync data for key %s: %s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: "" ) )
+				sprintf( esc_attr__( 'Failed to update sync data for key %1$s: %2$s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: "" ) )
 			);
 		}
 

--- a/src/Sync_Data.php
+++ b/src/Sync_Data.php
@@ -102,10 +102,10 @@ trait Sync_Data {
 		}
 
 		$success = Data_DB::db()->replace( $this->get_sync_data_name() . '_' . $key, $updates, $expiration );
-		if ( ! $success ) {
+		if ( false === $success ) {
 			throw new Exception(
 			/* translators: 1: The key name of the sync data trying to update., 2: The last db error. */
-				sprintf( esc_attr__( 'Failed to update sync data for key %1$s: %2$s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->last_error ?: '' ) )
+				sprintf( esc_attr__( 'Failed to update sync data for key %1$s: %2$s', 'as-processor' ), esc_attr( $key ), esc_attr( Data_DB::db()->get_last_error() ) )
 			);
 		}
 


### PR DESCRIPTION
Accepts 0 affected rows for sync_data updates, while also adding the last sql error to the exception if an update of sync_data failed