### PR TITLE
Enhance array merging functionality to support custom numeric keys

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -174,6 +174,9 @@ class Helper {
 	/**
 	 * Merges two arrays with options for deep merging and array concatenation.
 	 *
+	 * For flat arrays with sequential indexed keys (0, 1, 2...), values are concatenated.
+	 * For arrays with custom numeric keys, keys are preserved and values from array2 override array1.
+	 *
 	 * @param array $array1 The original array.
 	 * @param array $array2 The array to merge into the original array.
 	 * @param bool  $deep_merge Optional. Flag to control deep merging. Default is false.
@@ -183,7 +186,7 @@ class Helper {
 	public static function merge_arrays( array $array1, array $array2, bool $deep_merge = false, bool $concat_arrays = false ): array {
 		// Check if both arrays are flat
 		if ( self::is_flat_array( $array1 ) && self::is_flat_array( $array2 ) ) {
-			return array_merge( $array1, $array2 );
+			return self::merge_flat_arrays( $array1, $array2 );
 		} else {
 			foreach ( $array2 as $key => $value ) {
 				if ( ! isset( $array1[ $key ] ) || ( ! is_array( $value ) && ! is_array( $array1[ $key ] ) ) ) {
@@ -271,5 +274,27 @@ class Helper {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Merges two flat arrays while preserving custom numeric keys.
+	 *
+	 * If both arrays are indexed arrays (sequential 0, 1, 2...), concatenates them.
+	 * Otherwise, preserves all keys and values from array2 override array1.
+	 *
+	 * @param array $array1 The original flat array.
+	 * @param array $array2 The flat array to merge.
+	 * @return array The merged flat array.
+	 */
+	private static function merge_flat_arrays( array $array1, array $array2 ): array {
+		$both_indexed = self::is_indexed_array( $array1 ) && self::is_indexed_array( $array2 );
+
+		if ( $both_indexed ) {
+			// For sequential indexed arrays, concatenate values
+			return array_merge( $array1, $array2 );
+		}
+
+		// For arrays with custom numeric keys or associative keys, preserve all keys
+		return $array2 + $array1;
 	}
 }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -96,6 +96,27 @@ class HelperTest extends TestCase
 				false,
 				[123, 1234, 12345, 456, 4567, 45678]
 			],
+			'Flat array with custom numeric keys' => [
+				[100 => 'value1', 200 => 'value2'],
+				[300 => 'value3', 400 => 'value4'],
+				false,
+				false,
+				[100 => 'value1', 200 => 'value2', 300 => 'value3', 400 => 'value4']
+			],
+			'Flat array with overlapping custom numeric keys' => [
+				[100 => 'value1', 200 => 'value2'],
+				[200 => 'value2_updated', 300 => 'value3'],
+				true,
+				false,
+				[100 => 'value1', 200 => 'value2_updated', 300 => 'value3']
+			],
+			'Flat array mixed numeric and string keys' => [
+				[100 => 'value1', 'key1' => 'value2'],
+				[200 => 'value3', 'key2' => 'value4'],
+				false,
+				false,
+				[100 => 'value1', 'key1' => 'value2', 200 => 'value3', 'key2' => 'value4']
+			],
         ];
     }
 


### PR DESCRIPTION
This pull request enhances the array merging functionality in the `Helper` class by improving how flat arrays are merged, especially when custom numeric or mixed keys are involved. It introduces a new private method to handle these cases, updates the main merge logic to use it, and expands test coverage to ensure correct behavior for various flat array scenarios.

**Array merging improvements:**

* Updated the `merge_arrays` method to use a new `merge_flat_arrays` helper for merging flat arrays, ensuring custom numeric keys are preserved and values from the second array override the first when keys overlap.
* Added a new private method `merge_flat_arrays` to handle merging of flat arrays, differentiating between sequential indexed arrays (which are concatenated) and arrays with custom numeric or mixed keys (which are merged with key preservation and overriding).
* Improved the method documentation to clarify the behavior for flat arrays with sequential and custom numeric keys.

**Testing enhancements:**

* Added new test cases in `mergeArraysProvider` to cover merging flat arrays with custom numeric keys, overlapping keys, and mixed numeric/string keys, ensuring the new logic is thoroughly tested.