### PR TITLE
Add AS Processor bootstrap registrar

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,29 @@
+---
+description: Register AS Processor runtime hooks from a WordPress plugin.
+---
+
+# Bootstrap AS Processor
+
+Call `AS_Processor::register()` once from your plugin bootstrap after Composer's autoloader is available:
+
+```php
+use juvo\AS_Processor\AS_Processor;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+AS_Processor::register();
+```
+
+The method registers the shared cleanup callback and the Action Scheduler recurring-action check. It is idempotent, so multiple calls in the same request are safe.
+
+You do not need to call it on a specific WordPress hook such as `plugins_loaded`. Call it early enough that Action Scheduler requests have the `asp/cleanup` callback registered.
+
+`AS_Processor::register()` checks only the current request's in-memory WordPress hook registry. It does not query the database. It should still run on every request because WordPress hook callbacks are not persisted between requests.
+
+Import classes are separate from the shared runtime bootstrap. Keep import instances alive on requests where their Action Scheduler callbacks may run.
+
+## Cleanup Action
+
+The cleanup job uses the global `asp/cleanup` hook. Action Scheduler ensures the recurring action through `action_scheduler_ensure_recurring_actions`; when the action is missing, AS Processor schedules it to run daily at midnight.
+
+The cleanup action removes expired chunk tracking rows and expired sync data.

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,20 @@ The package ships with runtime support for Action Scheduler integrations plus CS
 
 Development and test assets stay in the repository, but they are excluded from package archives and production autoloading. Consumers only get the runtime library under `src/`.
 
+### Bootstrap
+
+Register the shared runtime hooks from your plugin bootstrap:
+
+```php
+use juvo\AS_Processor\AS_Processor;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+AS_Processor::register();
+```
+
+See [Bootstrap AS Processor](docs/bootstrap.md) for details.
+
 ### Testing
 
 The repository includes two PHPUnit 9 test suites, and both run inside the `wp-env` `tests-cli` container.
@@ -47,7 +61,7 @@ The unit suite runs from the library root inside `wp-env`, while the application
 
 5. **Reliable Sync Management**:
     - Built-in sync lifecycle management, including hooks for starting, progressing, and completing synchronizations.
-    - Automatic cleanup of completed tasks and retention of synchronization data for specified durations.
+    - Automatic cleanup of completed tasks and retention of synchronization data for specified durations after `AS_Processor::register()` is called from the host plugin.
 
 6. **Error Handling and Recovery**:
     - Exception handling is seamlessly integrated at every critical stage, ensuring the process fails gracefully and any issues are recorded for diagnosis.

--- a/src/AS_Processor.php
+++ b/src/AS_Processor.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Registers shared AS Processor runtime hooks.
+ *
+ * @package juvo/as-processor
+ */
+
+namespace juvo\AS_Processor;
+
+use juvo\AS_Processor\DB\Chunk_DB;
+use juvo\AS_Processor\DB\Data_DB;
+
+/**
+ * Library bootstrap for hooks that must exist independently of sync instances.
+ */
+final class AS_Processor {
+
+	/**
+	 * Register shared runtime hooks.
+	 *
+	 * Implementing plugins should call this once during their bootstrap, after
+	 * WordPress is loaded and before Action Scheduler runs queued actions.
+	 * WordPress hook registrations are request-local, so this method must not
+	 * skip registration based on a persisted option from a previous request.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		if ( false === has_action( 'action_scheduler_ensure_recurring_actions', array( self::class, 'ensure_recurring_actions' ) ) ) {
+			add_action( 'action_scheduler_ensure_recurring_actions', array( self::class, 'ensure_recurring_actions' ) );
+		}
+
+		if ( false === has_action( 'asp/cleanup', array( self::class, 'cleanup' ) ) ) {
+			add_action( 'asp/cleanup', array( self::class, 'cleanup' ) );
+		}
+	}
+
+	/**
+	 * Ensure the library's recurring actions remain scheduled.
+	 *
+	 * @return void
+	 */
+	public static function ensure_recurring_actions(): void {
+		if ( as_has_scheduled_action( 'asp/cleanup' ) ) {
+			return;
+		}
+
+		// Run the cleanup at midnight every day.
+		as_schedule_cron_action(
+			time(),
+			'0 0 * * *',
+			'asp/cleanup'
+		);
+	}
+
+	/**
+	 * Remove expired chunk tracking rows and sync data.
+	 *
+	 * @return void
+	 */
+	public static function cleanup(): void {
+		Chunk_DB::db()->cleanup();
+		Data_DB::db()->delete_expired_data();
+	}
+}

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -13,7 +13,6 @@ use ActionScheduler_Action;
 use ActionScheduler_Store;
 use Exception;
 use juvo\AS_Processor\DB\Chunk_DB;
-use juvo\AS_Processor\DB\Data_DB;
 use juvo\AS_Processor\Entities\Chunk;
 use juvo\AS_Processor\Entities\ProcessStatus;
 
@@ -104,30 +103,6 @@ abstract class Sync implements Syncable {
 
 		// If Sync failed execute on_fail
 		add_action( $this->get_sync_name() . '/fail', array( $this, 'on_fail' ) );
-
-		// Hook Sync DB Cleanup
-		add_action(
-			'init',
-			function () {
-				if ( as_has_scheduled_action( 'asp/cleanup' ) ) {
-					return;
-				}
-
-				// schedule the cleanup midnight every day
-				as_schedule_cron_action(
-					time(),
-					'0 0 * * *',
-					'asp/cleanup'
-				);
-			}
-		);
-		add_action(
-			'asp/cleanup',
-			function () {
-				Chunk_DB::db()->cleanup();
-				Data_DB::db()->delete_expired_data();
-			}
-		);
 	}
 
 	/**

--- a/tests/e2e/demo-plugin/as-processor-demo.php
+++ b/tests/e2e/demo-plugin/as-processor-demo.php
@@ -12,6 +12,8 @@
 
 namespace AS_Processor_Demo;
 
+use juvo\AS_Processor\AS_Processor;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -29,6 +31,8 @@ if ( ! file_exists( $autoload ) ) {
 
 require_once $autoload;
 require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
+
+AS_Processor::register();
 
 define( 'ASP_DEMO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ASP_DEMO_DATA_DIR', ASP_DEMO_PLUGIN_DIR . 'data/' );

--- a/tests/e2e/demo-plugin/tests/php/Chunk_Database_Test.php
+++ b/tests/e2e/demo-plugin/tests/php/Chunk_Database_Test.php
@@ -10,8 +10,10 @@ namespace AS_Processor_Demo\Tests\Integration;
 
 use AS_Processor_Demo\Product_CSV_Import;
 use AS_Processor_Demo\Tests\Support\E2E_Test_Case;
+use juvo\AS_Processor\AS_Processor;
 use juvo\AS_Processor\DB\Chunk_DB;
 use juvo\AS_Processor\Entities\ProcessStatus;
+use WP_Hook;
 
 /**
  * @group database
@@ -102,5 +104,46 @@ class Chunk_Database_Test extends E2E_Test_Case {
 		$this->assertSame( 0, Chunk_DB::db()->get_total_actions( $old_finished_group ) );
 		$this->assertSame( 1, Chunk_DB::db()->get_total_actions( $recent_finished_group ) );
 		$this->assertSame( 1, Chunk_DB::db()->get_total_actions( $old_failed_group ) );
+	}
+
+	public function test_action_scheduler_ensure_recurring_actions_schedules_asp_cleanup(): void {
+		as_unschedule_all_actions( 'asp/cleanup' );
+
+		$this->assertFalse( as_has_scheduled_action( 'asp/cleanup' ) );
+
+		do_action( 'action_scheduler_ensure_recurring_actions' );
+
+		$this->assertTrue( as_has_scheduled_action( 'asp/cleanup' ) );
+
+		as_unschedule_all_actions( 'asp/cleanup' );
+	}
+
+	public function test_as_processor_register_is_idempotent(): void {
+		$cleanup_callbacks   = $this->count_registered_callbacks( 'asp/cleanup' );
+		$recurring_callbacks = $this->count_registered_callbacks( 'action_scheduler_ensure_recurring_actions' );
+
+		AS_Processor::register();
+		AS_Processor::register();
+
+		$this->assertSame( $cleanup_callbacks, $this->count_registered_callbacks( 'asp/cleanup' ) );
+		$this->assertSame( $recurring_callbacks, $this->count_registered_callbacks( 'action_scheduler_ensure_recurring_actions' ) );
+		$this->assertSame( 10, has_action( 'asp/cleanup', array( AS_Processor::class, 'cleanup' ) ) );
+		$this->assertSame( 10, has_action( 'action_scheduler_ensure_recurring_actions', array( AS_Processor::class, 'ensure_recurring_actions' ) ) );
+	}
+
+	private function count_registered_callbacks( string $hook ): int {
+		global $wp_filter;
+
+		if ( empty( $wp_filter[ $hook ] ) || ! $wp_filter[ $hook ] instanceof WP_Hook ) {
+			return 0;
+		}
+
+		$count = 0;
+
+		foreach ( $wp_filter[ $hook ]->callbacks as $callbacks ) {
+			$count += count( $callbacks );
+		}
+
+		return $count;
 	}
 }


### PR DESCRIPTION
## Summary
- add AS_Processor::register() as the shared runtime bootstrap for cleanup hooks
- move asp/cleanup registration out of individual Sync instances
- document direct bootstrap usage and add E2E coverage for idempotent registration

## Tests
- wp-env unit PHPUnit suite: OK (22 tests, 44 assertions)
- wp-env E2E PHPUnit suite: OK (19 tests, 202 assertions)