### PR TITLE
Rework asp_chunks indexes around group-led query shapes

### DIFF
--- a/src/DB/Chunk_DB.php
+++ b/src/DB/Chunk_DB.php
@@ -51,7 +51,9 @@ class Chunk_DB extends Base_DB {
             KEY `status` (`status`),
             KEY `start` (`start`),
             KEY `end` (`end`),
-            KEY `action_id` (`action_id`)
+            KEY `action_id` (`action_id`),
+            KEY `group_name` (`group`),
+            KEY `group_status` (`group`, `status`)
         ) {$charset_collate}";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/src/DB/Chunk_DB.php
+++ b/src/DB/Chunk_DB.php
@@ -48,16 +48,48 @@ class Chunk_DB extends Base_DB {
             `end` decimal(14,4) DEFAULT NULL,
             `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`),
-            KEY `status` (`status`),
-            KEY `start` (`start`),
-            KEY `end` (`end`),
             KEY `action_id` (`action_id`),
-            KEY `group_name` (`group`),
-            KEY `group_status` (`group`, `status`)
+            KEY `group_status` (`group`, `status`),
+            KEY `group_start` (`group`, `start`),
+            KEY `group_end` (`group`, `end`)
         ) {$charset_collate}";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+
+		$this->drop_obsolete_indexes();
+	}
+
+	/**
+	 * Drops indexes that no query targets, so they do not slow down writes.
+	 *
+	 * Every read against this table is group-led, so the group-prefixed compound
+	 * indexes (`group_status`, `group_start`, `group_end`) cover all real query
+	 * shapes. The single-column `status`, `start` and `end` indexes — and the
+	 * short-lived `group_name` index, which is a redundant leftmost prefix of the
+	 * compound indexes — are therefore obsolete. `dbDelta()` only ever adds or
+	 * modifies indexes and never removes them, so they must be dropped explicitly
+	 * for existing installations. The lookup against `information_schema` keeps
+	 * this idempotent and avoids errors on installs where they are already gone.
+	 *
+	 * @return void
+	 */
+	private function drop_obsolete_indexes(): void {
+		$table_name = $this->get_table_name();
+
+		$existing_indexes = $this->db->get_col(
+			$this->db->prepare(
+				'SELECT DISTINCT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+				$table_name
+			)
+		);
+
+		$obsolete_indexes = array( 'status', 'start', 'end', 'group_name' );
+
+		foreach ( array_intersect( $obsolete_indexes, $existing_indexes ) as $index_name ) {
+			// $table_name and $index_name are both from trusted sources (table prefix and a fixed whitelist), so they are safe to interpolate; identifiers cannot be bound via prepare().
+			$this->db->query( "ALTER TABLE `{$table_name}` DROP INDEX `{$index_name}`" );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Reworks the indexes on `asp_chunks` so they match the table's **query shapes** instead of indexing one column at a time. Every read against this table filters by `group` first, so the indexes are now group-led compounds, and the single-column indexes that no query can use are removed.

### Indexes after this change
- `PRIMARY (id)`
- `action_id (action_id)` — `get_chunk_by_action_id`
- `group_status (group, status)` — hot path: `are_all_chunks_completed`, `get_chunks_by_status`; its `group` prefix also covers every group-only lookup
- `group_start (group, start)` — `get_sync_start` / duration / slowest-fastest stats
- `group_end (group, end)` — `get_sync_end` / duration stats

### Removed
- `group_name (group)` — redundant; it is the leftmost prefix of the compound indexes
- `status (status)` — only ever used by a non-default `cleanup` status filter, on a low-cardinality column
- `start (start)`, `end (end)` — no query uses them standalone (all access is group-led; `cleanup`'s `OR created_at` defeats them anyway)

Fewer indexes = less write amplification on the per-chunk upsert (`replace()`), which runs on every lifecycle transition.

## Migration

`dbDelta()` only ever **adds** indexes, never drops them, so removing the `KEY` lines alone would leave the obsolete indexes on existing installs. `drop_obsolete_indexes()` runs after `dbDelta()` and drops them explicitly, guarded by an `information_schema` lookup so it is idempotent and safe on installs where they are already gone.

## Verification

Run locally against this branch in the project's wp-env (MySQL):
- `phpstan analyse` — **No errors**
- `phpcs src/DB/Chunk_DB.php` — **clean**
- Real-DB upgrade simulation (old indexes → dbDelta add → `drop_obsolete_indexes`): final index set is exactly `PRIMARY, action_id, group_status, group_start, group_end`. Confirms reserved-word quoting (`group`/`start`/`end`) and the `varchar(255)`+`varchar(255)` compound width are accepted.

## Test plan
- [ ] `composer run phpstan` exits 0
- [ ] `npm test` (unit + E2E) passes — the E2E suite exercises the real `dbDelta` + `Chunk_DB::db()` path

🤖 Generated via the `/improve` skill (plan 001), extended per review.