### PR TITLE
Fix Stats null-safety, filter name typo, and API comparison bugs

### DIFF
--- a/src/Imports/API.php
+++ b/src/Imports/API.php
@@ -50,7 +50,7 @@ abstract class API extends Import
     {
 
         // Maybe set current index. Default value can be set with class parameter in child implementation
-        if ($index != null) {
+        if ($index !== null) {
             $this->index = $index;
         }
 
@@ -101,7 +101,9 @@ abstract class API extends Import
 
         // If this was the last request schedule chunk as well. Else schedule request
         if ($this->next === false) {
-            $this->schedule_chunk($items);
+            if (!empty($items)) {
+                $this->schedule_chunk($items);
+            }
         } else {
             if ($this->time_between_requests >= 15) {
                 // Longer request intervals (> 15 sec) are scheduled since they would unnecessarily keep php requests alive

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -47,8 +47,8 @@ class Stats
             'total_actions'           => Chunk_DB::db()->get_total_actions($this->group_name),
             'sync_duration'           => Chunk_DB::db()->get_sync_duration($this->group_name),
             'average_action_duration' => Chunk_DB::db()->get_average_action_duration($this->group_name),
-            'slowest_action'          => Chunk_DB::db()->get_slowest_action($this->group_name)->setJsonExcludedFields($excludedFields),
-            'fastest_action'          => Chunk_DB::db()->get_fastest_action($this->group_name)->setJsonExcludedFields($excludedFields),
+            'slowest_action'          => Chunk_DB::db()->get_slowest_action($this->group_name)?->setJsonExcludedFields($excludedFields),
+            'fastest_action'          => Chunk_DB::db()->get_fastest_action($this->group_name)?->setJsonExcludedFields($excludedFields),
             'actions'                 => $actions,
             'custom_data'             => $custom_data
         ];
@@ -88,8 +88,8 @@ class Stats
             foreach ($failed_actions as $chunk) {
                 $email_text .= sprintf(__("Action ID: %s", 'as-processor'), $chunk->get_action_id()) . "\n";
                 $email_text .= sprintf(__("Status: %s", 'as-processor'), $chunk->get_status()->value) . "\n";
-                $email_text .= sprintf(__("Start: %s", 'as-processor'), $chunk->get_start()->format("Y-m-d H:i:s.u T")) . "\n";
-                $email_text .= sprintf(__("End: %s", 'as-processor'), $chunk->get_end()->format("Y-m-d H:i:s.u T")) . "\n";
+                $email_text .= sprintf(__("Start: %s", 'as-processor'), $chunk->get_start()?->format("Y-m-d H:i:s.u T") ?? 'N/A') . "\n";
+                $email_text .= sprintf(__("End: %s", 'as-processor'), $chunk->get_end()?->format("Y-m-d H:i:s.u T") ?? 'N/A') . "\n";
 
 				if ($chunk->get_status()->value === 'failed') {
                     $email_text .= __("Log Messages:", 'as-processor') . "\n";
@@ -118,9 +118,9 @@ class Stats
 	{
 
 		$message = $this->prepare_email_text($custom_data);
-		$mailarray = apply_filters('asp/stats/remail_report', [
+		$mailarray = apply_filters('asp/stats/email_report', [
 			'to'      => $to ?: get_option('admin_email'),
-			'subject' => $subject ?: sprintf(__('[%s] Report of sync group %s', 'sinnewerk'), get_bloginfo('name'), $this->group_name),
+			'subject' => $subject ?: sprintf(__('[%s] Report of sync group %s', 'as-processor'), get_bloginfo('name'), $this->group_name),
 			'message' => $message
 		]);
 		wp_mail($mailarray['to'], $mailarray['subject'], $mailarray['message']);


### PR DESCRIPTION
## Summary

Five runtime bugs across two files.

**`src/Stats.php`:**
1. **NPE in `to_json()`** — `get_slowest_action()` / `get_fastest_action()` return `?Chunk`; calling `->setJsonExcludedFields()` on `null` (no completed chunks) was a fatal error. Fixed with `?->`.
2. **NPE in `prepare_email_text()`** — failed chunks have `null` start/end; `->format()` on them was fatal. Fixed with `?->format(...) ?? 'N/A'`.
3. **Filter typo + wrong text domain** — `asp/stats/remail_report` → `asp/stats/email_report`, and one stray `'sinnewerk'` text domain → `'as-processor'`.

**`src/Imports/API.php`:**
4. **Loose comparison** — `if ($index != null)` silently ignored `$index = 0` (offset-based first page). Changed to `!== null`.
5. **Empty trailing chunk** — exact-multiple pagination scheduled `schedule_chunk([])`, creating a wasted Action Scheduler action. Guarded with `!empty($items)`.

## ⚠️ Breaking change

The filter rename `remail_report` → `email_report` will break any host plugin hooking the old (mistyped) name. Unlikely anyone hooked the typo successfully, but worth a changelog note. `to_json()` now returns `null` for slowest/fastest action when no chunks have completed — consumers must null-check.

## Test plan

- [x] `npm run test:unit` — 22 tests, 44 assertions OK
- [x] `npm run test:e2e` — 27 tests, 241 assertions OK

🤖 Generated via the `/improve` skill (plan 003).