### PR TITLE
Skip finish-checks while an API import is still fetching

### DIFF
--- a/src/Finish_Tracking.php
+++ b/src/Finish_Tracking.php
@@ -42,6 +42,24 @@ trait Finish_Tracking {
 	}
 
 	/**
+	 * Whether the run has produced all of its work, so a finish-check could
+	 * actually succeed.
+	 *
+	 * Defaults to true: most syncs schedule all of their work before any of it
+	 * runs, so a finish-check is always meaningful. Syncs that keep scheduling
+	 * work across several actions — for example a paginated API import that adds
+	 * chunks and follow-up fetches until the last page — override this so they do
+	 * not spawn a finish-check on every wave while finish provably cannot fire
+	 * yet. This must be monotonic: once it returns true it must keep returning
+	 * true, so the final, decisive finish-check is never suppressed.
+	 *
+	 * @return bool
+	 */
+	protected function finish_check_ready(): bool {
+		return true;
+	}
+
+	/**
 	 * Schedule the deferred finish-check action for the current run.
 	 *
 	 * Called from every work-action completion. At most one finish-check is kept
@@ -52,6 +70,13 @@ trait Finish_Tracking {
 	 * @return void
 	 */
 	protected function schedule_finish_check(): void {
+		// Skip while the run is still producing work (e.g. an API import mid
+		// pagination): a finish-check could not succeed yet, so scheduling one
+		// per completion wave would only add noise.
+		if ( ! $this->finish_check_ready() ) {
+			return;
+		}
+
 		$group = $this->get_sync_group_name();
 		$hook  = $this->get_finish_check_hook();
 

--- a/src/Imports/API.php
+++ b/src/Imports/API.php
@@ -253,8 +253,21 @@ abstract class API extends Import
             return; // There are still pending or running fetch actions
         }
 
-        // Mark fetching as done. The finish hook is fired by Sync::handle_complete()
-        // once should_trigger_finish() confirms all chunks completed as well.
+        // Mark fetching as done. The finish hook is then fired by the deferred
+        // finish-check once all chunks have completed as well.
         $this->update_sync_data( 'spawning_action_ended_at', time() );
+    }
+
+    /**
+     * API imports keep scheduling work — chunks and follow-up fetches — until the
+     * last page has been fetched, so a finish-check cannot succeed before then.
+     * Gate finish-check scheduling on the spawning-ended marker so a paginated
+     * import does not spawn a finish-check on every fetch wave. The marker is set
+     * once (in on_complete) and never cleared, so this stays monotonic.
+     *
+     * @return bool
+     */
+    protected function finish_check_ready(): bool {
+        return (bool) $this->get_sync_data( 'spawning_action_ended_at' );
     }
 }

--- a/tests/e2e/demo-plugin/tests/php/API_Import_Test.php
+++ b/tests/e2e/demo-plugin/tests/php/API_Import_Test.php
@@ -8,6 +8,7 @@
 namespace AS_Processor_Demo\Tests\Integration;
 
 use AS_Processor_Demo\Product_API_Import;
+use AS_Processor_Demo\Tests\Support\Action_Scheduler_Test_Helper;
 use AS_Processor_Demo\Tests\Support\E2E_Test_Case;
 use WP_REST_Request;
 
@@ -45,6 +46,32 @@ class API_Import_Test extends E2E_Test_Case {
 			count( $this->get_action_ids( Product_API_Import::SYNC_NAME . '/process_chunk', 'pending', $group ) )
 		);
 
+		$this->run_sync_to_completion( Product_API_Import::SYNC_NAME, $group );
+		$this->assert_sync_finished( $group );
+		$this->assertSame( 35, $this->get_post_count( 'asp_api_item' ) );
+	}
+
+	public function test_api_finish_check_is_not_scheduled_while_still_fetching(): void {
+		$root  = $this->schedule_import( Product_API_Import::SYNC_NAME );
+		$group = $this->run_root_action_and_get_group( Product_API_Import::SYNC_NAME, $root );
+
+		// After the first page a follow-up fetch is still queued and the
+		// spawning-ended marker is not set yet.
+		$fetch_ids = $this->get_action_ids( Product_API_Import::SYNC_NAME, 'pending', $group );
+		$this->assertNotEmpty( $fetch_ids, 'Expected a follow-up fetch while paginating.' );
+
+		// Completing a fetch mid-pagination must NOT schedule a finish-check —
+		// finish cannot fire until the last page is in, so spawning one per fetch
+		// wave would just add noise.
+		Action_Scheduler_Test_Helper::run_action( $fetch_ids[0] );
+
+		$this->assertCount(
+			0,
+			$this->get_action_ids( Product_API_Import::SYNC_NAME . '/finish_check', 'pending', $group ),
+			'No finish-check should be scheduled while the API import is still fetching.'
+		);
+
+		// The import still finishes correctly once it drains to completion.
 		$this->run_sync_to_completion( Product_API_Import::SYNC_NAME, $group );
 		$this->assert_sync_finished( $group );
 		$this->assertSame( 35, $this->get_post_count( 'asp_api_item' ) );


### PR DESCRIPTION
## Summary

Follow-up to #80. Stops paginated **API imports** from spawning a `{sync}/finish_check` action on every fetch wave.

## Problem

For a paginated API import, work keeps being scheduled (chunks + follow-up fetches) until the last page is fetched, so a finish-check **provably cannot succeed** until `spawning_action_ended_at` is set. The deferred-finish design scheduled one on every completion wave anyway, so a long, throttled import showed repeated `{sync}/finish_check` entries throughout — each ran, found work still pending, and exited. Correct, but noisy and wasteful (observed e.g. on `autoscout_ch/vehicles`).

## Fix

- New **monotonic** `finish_check_ready()` gate on the `Finish_Tracking` trait (default `true`); `schedule_finish_check()` returns early when it's `false`.
- `API` overrides it to require `spawning_action_ended_at`.

Because the marker is set once and never cleared, the gate only suppresses checks that couldn't have fired anyway. Once spawning ends it's `true` and scheduling is unconditional again — so the final, decisive finish-check is **never** suppressed (no re-introduced zero-fire race). Base syncs and file imports are unaffected (gate stays `true`).

Result: finish-checks are created only during the final drain, ~1 instead of one-per-fetch-wave.

## Testing (wp-env)

- New `test_api_finish_check_is_not_scheduled_while_still_fetching`.
- E2E **29 / 284**, unit **22 / 44**, PHPStan + PHPCS clean.
